### PR TITLE
Validation window when compound is validated

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -31,6 +31,8 @@ import { TabsComponent } from './tabs/tabs.component';
 import { FlashcardListComponent } from './components/flashcard-list/flashcard-list.component';
 import { FlashcardComponent } from './components/flashcard/flashcard.component';
 import { FlashcardCreateComponent } from './components/flashcard-create/flashcard-create.component';
+import { ValidationModalComponent } from './compound/validation-modal/validation-modal.component';
+import {MatDialogModule, MatDialogRef} from "@angular/material/dialog";
 
 @NgModule({
   declarations: [
@@ -45,7 +47,8 @@ import { FlashcardCreateComponent } from './components/flashcard-create/flashcar
     UserComponent,
     FlashcardListComponent,
     FlashcardComponent,
-    FlashcardCreateComponent
+    FlashcardCreateComponent,
+    ValidationModalComponent
   ],
   imports: [
     BrowserModule,
@@ -57,6 +60,7 @@ import { FlashcardCreateComponent } from './components/flashcard-create/flashcar
     BrowserAnimationsModule,
     MatCardModule,
     MatTabsModule,
+    MatDialogModule,
     MatToolbarModule,
     MatButtonModule,
     FlexLayoutModule,

--- a/src/app/compound/compound.component.html
+++ b/src/app/compound/compound.component.html
@@ -1,14 +1,34 @@
 <h1 id="title">Compound</h1>
 <div>
+  <div [ngClass]="displayModal ? 'modal fade' : 'modal'" id="exampleModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="exampleModalLabel">Modal title</h5>
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+        <div class="modal-body">
+          ...
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+          <button type="button" class="btn btn-primary">Save changes</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <ng-container *ngIf="elementsInCompound.length > 0">
     <div class="compound">
-      <div class="element-in-compound" *ngFor="let element of elementsInCompound; index as i" (click)="removeElementFromCompound(i, element)" 
+      <div class="element-in-compound" *ngFor="let element of elementsInCompound; index as i" (click)="removeElementFromCompound(i, element)"
         [ngStyle]="{'background-color': '#' + element?.cPKHexColor}">
           {{element?.symbol}}
       </div>
     </div>
   </ng-container>
   <div id="validate-btn" *ngIf="elementsInCompound.length > 0">
-    <button mat-raised-button color="primary" (click)="validateCompound()">Validate Compound</button>
+    <button mat-raised-button color="primary" data-target="#exampleModal" data-toggle="modal" (click)="validateCompound()">Validate Compound</button>
   </div>
 </div>

--- a/src/app/compound/compound.component.html
+++ b/src/app/compound/compound.component.html
@@ -1,25 +1,5 @@
 <h1 id="title">Compound</h1>
 <div>
-  <div [ngClass]="displayModal ? 'modal fade' : 'modal'" id="exampleModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
-    <div class="modal-dialog" role="document">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h5 class="modal-title" id="exampleModalLabel">Modal title</h5>
-          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-            <span aria-hidden="true">&times;</span>
-          </button>
-        </div>
-        <div class="modal-body">
-          ...
-        </div>
-        <div class="modal-footer">
-          <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-          <button type="button" class="btn btn-primary">Save changes</button>
-        </div>
-      </div>
-    </div>
-  </div>
-
   <ng-container *ngIf="elementsInCompound.length > 0">
     <div class="compound">
       <div class="element-in-compound" *ngFor="let element of elementsInCompound; index as i" (click)="removeElementFromCompound(i, element)"
@@ -29,6 +9,6 @@
     </div>
   </ng-container>
   <div id="validate-btn" *ngIf="elementsInCompound.length > 0">
-    <button mat-raised-button color="primary" data-target="#exampleModal" data-toggle="modal" (click)="validateCompound()">Validate Compound</button>
+    <button mat-raised-button color="primary" (click)="validateCompound()">Validate Compound</button>
   </div>
 </div>

--- a/src/app/compound/compound.component.ts
+++ b/src/app/compound/compound.component.ts
@@ -1,4 +1,4 @@
-import {Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
+import {Component, Input, OnInit} from '@angular/core';
 import { Element } from '../model/element.model';
 import {Observable, Subscription} from "rxjs";
 import {CompoundService} from "../service/compound.service";
@@ -17,16 +17,11 @@ import {ValidationModalComponent} from "./validation-modal/validation-modal.comp
 export class CompoundComponent implements OnInit {
   private interacted: Boolean = false;
   private eventsSubscription: Subscription;
-  private modalSubscription: Subscription;
   elementsInCompound: Element[] = [];
   dialogRef: MatDialogRef<ValidationModalComponent>;
   atomsInCompound: Map<String, number> = new Map();
   @Input() interactedElement: Element;
   @Input() events: Observable<Element>;
-
-  displayModal: Boolean = false;
-  @Input() openModal: Observable<any>
-  @Output() signalModalEvent: EventEmitter<any> = new EventEmitter();
 
 
   constructor(private compoundService: CompoundService, private authenticationService: AuthenticationService, public dialog: MatDialog) { }
@@ -37,7 +32,6 @@ export class CompoundComponent implements OnInit {
 
   ngOnDestroy() {
     this.eventsSubscription.unsubscribe();
-    this.modalSubscription.unsubscribe();
   }
 
   public getInteracted(): Boolean {
@@ -61,10 +55,6 @@ export class CompoundComponent implements OnInit {
       this.atomsInCompound.set(element.symbol, tempAtoms + 1)
     }
     console.log("Call in Compound.\nSymbol: \n" + element.symbol);
-  }
-
-  public showModal() {
-    this.displayModal = !this.displayModal;
   }
 
   public removeElementFromCompound(index: number, element: Element) {

--- a/src/app/compound/compound.component.ts
+++ b/src/app/compound/compound.component.ts
@@ -3,17 +3,23 @@ import { Element } from '../model/element.model';
 import {Observable, Subscription} from "rxjs";
 import {CompoundService} from "../service/compound.service";
 import { AuthenticationService } from '../service/authentication.service';
+import {Compound} from "../model/compound";
+import {HttpErrorResponse, HttpResponse} from "@angular/common/http";
+import {MatDialog, MatDialogRef} from "@angular/material/dialog";
+import {ValidationModalComponent} from "./validation-modal/validation-modal.component";
 
 @Component({
   selector: 'app-compound',
   templateUrl: './compound.component.html',
   styleUrls: ['./compound.component.scss']
 })
+
 export class CompoundComponent implements OnInit {
   private interacted: Boolean = false;
   private eventsSubscription: Subscription;
   private modalSubscription: Subscription;
   elementsInCompound: Element[] = [];
+  dialogRef: MatDialogRef<ValidationModalComponent>;
   atomsInCompound: Map<String, number> = new Map();
   @Input() interactedElement: Element;
   @Input() events: Observable<Element>;
@@ -23,13 +29,10 @@ export class CompoundComponent implements OnInit {
   @Output() signalModalEvent: EventEmitter<any> = new EventEmitter();
 
 
-  constructor(private compoundService: CompoundService, private authenticationService: AuthenticationService) { }
+  constructor(private compoundService: CompoundService, private authenticationService: AuthenticationService, public dialog: MatDialog) { }
 
   ngOnInit(): void {
     this.eventsSubscription = this.events.subscribe((element) => this.addInteractedElements(element));
-    this.modalSubscription = this.openModal.subscribe(() => {
-      this.showModal();
-    });
   }
 
   ngOnDestroy() {
@@ -74,8 +77,29 @@ export class CompoundComponent implements OnInit {
     }
   }
 
-  public emitModalEvent(): void {
-    this.signalModalEvent.emit()
+  public openConfirmationDialogFail(response: HttpErrorResponse) {
+    this.dialogRef = this.dialog.open(ValidationModalComponent, {
+      disableClose: false
+    });
+
+    this.dialogRef.componentInstance.wasSuccessful = "Uh oh!"
+    if (response.status == 404) {
+      this.dialogRef.componentInstance.confirmMessage = "It doesn't look like that is a valid compound, please try again!"
+    } else {
+      this.dialogRef.componentInstance.confirmMessage = "We're having trouble validating...Please try again."
+    }
+  }
+
+  public openConfirmationDialogSuccess(response: HttpResponse<Compound>, isLoggedIn: boolean) {
+    this.dialogRef = this.dialog.open(ValidationModalComponent, {
+      disableClose: false
+    });
+    this.dialogRef.componentInstance.wasSuccessful = "Success!"
+    this.dialogRef.componentInstance.confirmMessage = "You've discovered: " + response.body.title;
+
+    if (!isLoggedIn) {
+      this.dialogRef.componentInstance.isLoggedIn = "Log in/register to save these results for a quiz!"
+    }
   }
 
   public validateCompound() {
@@ -97,7 +121,14 @@ export class CompoundComponent implements OnInit {
       // careful of memory leak
       this.compoundService
         .validate(payload)
-          .subscribe(response => console.log("You've discovered: " + response.body.title));
+          .subscribe({
+            next: (response: HttpResponse<Compound>) => {
+              this.openConfirmationDialogSuccess(response, true);
+            },
+            error: (errorResponse: HttpErrorResponse) => {
+              this.openConfirmationDialogFail(errorResponse);
+            }
+          });
     } else {
       console.warn("Unable to save findings, no user is logged in.");
       let payload = {
@@ -106,10 +137,14 @@ export class CompoundComponent implements OnInit {
       }
       // careful of memory leak
       this.compoundService
-      .validate(payload)
-        .subscribe(response => {
-          this.emitModalEvent();
-          console.log("You've discovered: " + response.body.title)
+        .validate(payload)
+        .subscribe({
+          next: (response: HttpResponse<Compound>) => {
+            this.openConfirmationDialogSuccess(response, false);
+          },
+          error: (errorResponse: HttpErrorResponse) => {
+            this.openConfirmationDialogFail(errorResponse)
+          }
         });
     }
   }

--- a/src/app/compound/validation-modal/validation-modal.component.html
+++ b/src/app/compound/validation-modal/validation-modal.component.html
@@ -1,0 +1,6 @@
+<h1 md-dialog-title>{{wasSuccessful}}</h1>
+<div md-dialog-content>{{confirmMessage}}</div>
+<div md-dialog-content>{{isLoggedIn}}</div>
+<div md-dialog-actions>
+  <button md-button style="color: #fff;background-color: #153961" (click)="dialogRef.close(true)">Ok</button>
+</div>

--- a/src/app/compound/validation-modal/validation-modal.component.spec.ts
+++ b/src/app/compound/validation-modal/validation-modal.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ValidationModalComponent } from './validation-modal.component';
+
+describe('ValidationModalComponent', () => {
+  let component: ValidationModalComponent;
+  let fixture: ComponentFixture<ValidationModalComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ValidationModalComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ValidationModalComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/compound/validation-modal/validation-modal.component.ts
+++ b/src/app/compound/validation-modal/validation-modal.component.ts
@@ -1,0 +1,15 @@
+import { Component } from '@angular/core';
+import { MatDialogRef } from '@angular/material/dialog';
+
+@Component({
+  selector: 'app-validation-modal',
+  templateUrl: './validation-modal.component.html'
+})
+export class ValidationModalComponent {
+
+  constructor(public dialogRef: MatDialogRef<ValidationModalComponent>) { }
+
+  public confirmMessage: string;
+  public wasSuccessful: string;
+  public isLoggedIn: string;
+}


### PR DESCRIPTION
Added a new modal when the compound is validated. The following messages are displayed back to the user:

- (Logged in) Success finding the compound
- (Not logged in) Success finding the compound, informs user to login/register to save results as a quiz
- Failure: 404 => informs the user that the compound is invalid
- Failure: _ => informs the user issues validating currently and to try again later.

Some more TLC can be done with the modal, but for now it is working and displays once the response is returned from the PUG API call or the DB.